### PR TITLE
Build.changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,18 @@ allprojects {
         in a public repo are distributed in the lib dir. */
         flatDir name: 'libDir', dirs: "lib"
 
+        /* a local cache for retrieved artifacts */
         mavenLocal()
+
+        /* things that aren't in Maven central */
         mavenRepo name: "gson", urls: "http://google-gson.googlecode.com/svn/mavenrepo"
-		mavenCentral()
+
+        /* the final resort - if you have a corporate repository server, set the URL
+           in ~/.gradle/gradle.properties */
+        if ( project.hasProperty('internalRepositoryUrl') )
+            mavenRepo urls: project.internalRepositoryUrl
+        else
+            mavenCentral()
     }
 }
 

--- a/s4-core/src/main/resources/s4-core/conf/default/log4j.xml
+++ b/s4-core/src/main/resources/s4-core/conf/default/log4j.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+  <appender name="R" class="org.apache.log4j.DailyRollingFileAppender">
+    <param name="File" value="${log_loc}/s4-core/s4-core_${instanceId}.log" />
+    <layout class="org.apache.log4j.PatternLayout"> 
+      <param name="ConversionPattern" value="%d %c %p (%F:%L) %m%n"/>
+    </layout> 
+  </appender> 
+  <appender name="S" class="org.apache.log4j.DailyRollingFileAppender">
+    <param name="File" value="${log_loc}/s4-core/s4-core_${instanceId}.mon" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d %c %p (%F:%L) %m%n"/>
+    </layout>
+  </appender>
+
   <logger name="com.yahoo" additivity="false">
         <level value="info"/>
         <appender-ref ref="R"/>
@@ -25,24 +39,9 @@
         <level value="info"/>
         <appender-ref ref="S"/>
   </logger>
-  <appender name="R" class="org.apache.log4j.DailyRollingFileAppender">
-    <param name="File" value="${log_loc}/s4-core/s4-core_${instanceId}.log" />
-    <layout class="org.apache.log4j.PatternLayout"> 
-      <param name="ConversionPattern" value="%d %c %p (%F:%L) %m%n"/>
-    </layout> 
-  </appender> 
-  <appender name="S" class="org.apache.log4j.DailyRollingFileAppender">
-    <param name="File" value="${log_loc}/s4-core/s4-core_${instanceId}.mon" />
-    <layout class="org.apache.log4j.PatternLayout">
-      <param name="ConversionPattern" value="%d %c %p (%F:%L) %m%n"/>
-    </layout>
-  </appender>
+
   <root> 
     <priority value ="info" /> 
     <appender-ref ref="R" /> 
   </root>
 </log4j:configuration>
-
-
-
-


### PR DESCRIPTION
The build script will always go to Maven Central to resolve its dependencies. For sites that have a local repository server, it is preferable to resolve dependencies against that server.

To make this happen, create the file $HOME/.gradle/gradle.properties (this is a standard file that is loaded by Gradle), and add the URL of your local repository as "internalRepositoryUrl". This property is used only if it exists; if it does not exist, then the default is to go to Maven Central.
