### PR TITLE
Fix the break of the ./gradlew allImage on Mac.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,9 @@ subprojects {
 
     /* Common dependencies applied to all subprojects. */
     dependencies { 
-        compile( libraries.log4j )
+        compile( libraries.log4j ) {
+			exclude group:'com.sun.jmx', module:'jmxri'
+		}
         compile( libraries.commons_logging )
         compile( libraries.spring )
         testCompile( libraries.junit )


### PR DESCRIPTION
The build error looks like the following:

./gradlew allImage
default
Got here:s4-comm:compileJava
error: error reading /Users/dikang/.gradle/cache/com.sun.jmx/jmxri/jars/jmxri-1.2.1.jar; cannot read zip file
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error

FAILURE: Build failed with an exception.
- What went wrong:
  Execution failed for task ':s4-comm:compileJava'.
  Cause: Compile failed; see the compiler error output for details.
- Try:
  Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 16.082 secs

The solution is to exclude the jmxri-1.2.1.jar in the compile, because we do not need that.
