### PR TITLE
Fix S4 project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 S4 - Stream Computing Platform
 ==============================
 
-For more information, see [s4.io](http://s4.io)
+For more information, see [http://incubator.apache.org/s4/](http://incubator.apache.org/s4/)
 
 Requirements
 ------------


### PR DESCRIPTION
It appears that [s4.io](http://s4.io) is no longer associated with this project. Update link to point at the Apache project page.

If accepted, don't forget to update the link in the GitHub project description.
